### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/master_merge.yml
+++ b/.github/workflows/master_merge.yml
@@ -157,6 +157,8 @@ jobs:
   # Smoketest on url change
   smoke-test-performance:
     needs: deploy
+    permissions:
+      contents: read
     uses: ./.github/workflows/performance.yml
     with:
       deployed_url: ${{ needs.deploy.outputs.page_url }}


### PR DESCRIPTION
Potential fix for [https://github.com/yoonghan/zoo/security/code-scanning/4](https://github.com/yoonghan/zoo/security/code-scanning/4)

To resolve the issue, add a `permissions` block to the `smoke-test-performance` job. This block should specify the minimal permissions required for the job to function correctly. Since the job appears to perform smoke tests on a deployed URL, it likely only requires read access to `contents`. If additional permissions are required for specific actions, they should be added explicitly.

The fix involves editing the `.github/workflows/master_merge.yml` file to include the `permissions` key under the `smoke-test-performance` job. This ensures that the job does not inherit excessive permissions from the repository.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
