### PR TITLE
Potential fix for code scanning alert no. 17: Cache Poisoning via caching of untrusted files

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -131,7 +131,7 @@ jobs:
             .next/cache
             ~/.cache/ms-playwright
           # Generate a new cache whenever packages or source files change.
-          key: ${{ runner.os }}-all-${{ hashFiles('**/package-lock.json', '**/yarn.lock') }}-${{ hashFiles('**.[jt]s', '**.[jt]sx') }}
+          key: ${{ runner.os }}-all-${{ hashFiles('**/package-lock.json', '**/yarn.lock') }}-${{ hashFiles('**.[jt]s', '**.[jt]sx') }}-${{ github.event.issue.number || github.sha }}
           # If source files changed but packages didn't, rebuild from a prior cache.
           restore-keys: |
             ${{ runner.os }}-all-${{ hashFiles('**/package-lock.json', '**/yarn.lock') }}-


### PR DESCRIPTION
Potential fix for [https://github.com/yoonghan/zoo/security/code-scanning/17](https://github.com/yoonghan/zoo/security/code-scanning/17)

**General fix:**  
To prevent cache poisoning, ensure that workflows which may handle untrusted code (e.g., those triggered by `issue_comment` or other untrusted events) do not write to caches that are accessible by privileged workflows or the default branch. The best practice is to scope such workflows to `pull_request` events, or to use unique, per-PR cache keys that cannot collide with those used in privileged workflows.

**Best fix for this code:**  
- Change the workflow trigger from `issue_comment` to `pull_request` (or, if secrets are needed, use `pull_request_target` with a manual approval label as described in the background).
- This ensures that the workflow only runs in the context of a pull request, and the cache is not shared with the default branch.
- Alternatively, if the `issue_comment` trigger is required, ensure that the cache key is unique per PR (e.g., by including the PR number or SHA in the cache key), so that untrusted PRs cannot poison the cache for the default branch or other PRs.
- The minimal fix is to add `${{ github.event.pull_request.number || github.event.issue.number || github.sha }}` to the cache key, ensuring cache isolation.

**What to change:**  
- In `.github/workflows/snapshot.yml`, update the cache key in the `Restore cache` step (line 134) to include a unique identifier for the PR or event, such as `${{ github.event.issue.number }}` or `${{ github.sha }}`.
- Optionally, consider changing the workflow trigger to `pull_request` for stronger isolation.

**Required:**  
- No new methods or imports are needed; only the cache key in the YAML file needs to be updated.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
